### PR TITLE
Update base image

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.12
 COPY registrator /registrator
 
 ENTRYPOINT ["/registrator"]


### PR DESCRIPTION
To fix security variabilities.

```
✗ High severity vulnerability found in openssl/libcrypto1.1
  Description: NULL Pointer Dereference
  Info: https://snyk.io/vuln/SNYK-ALPINE39-OPENSSL-588029
  Introduced through: openssl/libcrypto1.1@1.1.1b-r1, openssl/libssl1.1@1.1.1b-r1, apk-tools/apk-tools@2.10.3-r1, libtls-standalone/libtls-standalone@2.7.4-r6, ca-certificates/ca-certificates@20191127-r2, curl/libcurl@7.64.0-r4, libssh2/libssh2@1.9.0-r1
  From: openssl/libcrypto1.1@1.1.1b-r1
  From: openssl/libssl1.1@1.1.1b-r1 > openssl/libcrypto1.1@1.1.1b-r1
  From: apk-tools/apk-tools@2.10.3-r1 > openssl/libcrypto1.1@1.1.1b-r1
  and 8 more...
  Introduced in your Dockerfile by 'RUN apk add ca-certificates curl'
  Fixed in: 1.1.1g-r0

✗ High severity vulnerability found in musl/musl
  Description: Out-of-bounds Write
  Info: https://snyk.io/vuln/SNYK-ALPINE39-MUSL-458529
  Introduced through: musl/musl@1.1.20-r4, pax-utils/scanelf@1.2.3-r0, alpine-baselayout/alpine-baselayout@3.1.0-r3, openssl/libcrypto1.1@1.1.1b-r1, openssl/libssl1.1@1.1.1b-r1, zlib/zlib@1.2.11-r1, apk-tools/apk-tools@2.10.3-r1, libtls-standalone/libtls-standalone@2.7.4-r6, busybox/busybox@1.29.3-r10, ca-certificates/ca-certificates@20191127-r2, curl/libcurl@7.64.0-r4, curl/curl@7.64.0-r4, libssh2/libssh2@1.9.0-r1, nghttp2/nghttp2-libs@1.35.1-r2, musl/musl-utils@1.1.20-r4, busybox/ssl_client@1.29.3-r10, libc-dev/libc-utils@0.7.1-r0
  From: musl/musl@1.1.20-r4
  From: pax-utils/scanelf@1.2.3-r0 > musl/musl@1.1.20-r4
  From: alpine-baselayout/alpine-baselayout@3.1.0-r3 > musl/musl@1.1.20-r4
  and 15 more...
  Introduced in your Dockerfile by 'RUN apk add ca-certificates curl'
  Fixed in: 1.1.20-r5
```