### PR TITLE
fix: Support images with digests

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -246,9 +246,16 @@ func (b *Bridge) add(containerId string, quiet bool) {
 	}
 }
 
+func getServiceNameFromImage(image string) string {
+	return strings.Split(
+		strings.Split(path.Base(image), ":")[0],
+		"@",
+	)[0]
+}
+
 func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	container := port.container
-	defaultName := strings.Split(path.Base(container.Config.Image), ":")[0]
+	defaultName := getServiceNameFromImage(container.Config.Image)
 
 	// not sure about this logic. kind of want to remove it.
 	hostname := Hostname

--- a/bridge/bridge_test.go
+++ b/bridge/bridge_test.go
@@ -21,3 +21,32 @@ func TestNewValid(t *testing.T) {
 	assert.NotNil(t, bridge)
 	assert.NoError(t, err)
 }
+
+func Test_getServiceNameFromImage(t *testing.T) {
+	tests := []struct {
+		name    string
+		image   string
+		service string
+	}{
+		{
+			name:    "with tag",
+			image:   "123456789012.dkr.ecr.eu-west-1.amazonaws.com/foo/bar:v1.2.3",
+			service: "bar",
+		},
+		{
+			name:    "with digest",
+			image:   "123456789012.dkr.ecr.eu-west-1.amazonaws.com/foo/bar@sha256:abcc3e12da56ecf5756b48502baa2a98d09e69c5d033dc37ce93de77dc6cb123",
+			service: "bar",
+		},
+		{
+			name:    "with both",
+			image:   "123456789012.dkr.ecr.eu-west-1.amazonaws.com/foo/bar:v1.2.3@sha256:abcc3e12da56ecf5756b48502baa2a98d09e69c5d033dc37ce93de77dc6cb123",
+			service: "bar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.service, getServiceNameFromImage(tt.image), "getServiceNameFromImage(%v)", tt.image)
+		})
+	}
+}


### PR DESCRIPTION
If an image is of the format `<image>@sha256:<digest>` we need to correctly pull the service name out.